### PR TITLE
Feature 92: Affichage des categories que dans la page produit

### DIFF
--- a/src/main/webapp/app/components/categories/categories.module.ts
+++ b/src/main/webapp/app/components/categories/categories.module.ts
@@ -6,5 +6,8 @@ import { CategoriesComponent } from './display/categories.component';
 @NgModule({
   imports: [SharedModule, CategoriesRoutingModule],
   declarations: [CategoriesComponent],
+  exports: [
+    CategoriesComponent
+  ]
 })
 export class CategoriesModule {}

--- a/src/main/webapp/app/components/categories/display/categories.component.ts
+++ b/src/main/webapp/app/components/categories/display/categories.component.ts
@@ -5,7 +5,7 @@ import { HttpResponse } from '@angular/common/http';
 import { CategoriesService } from '../service/categories.service';
 
 @Component({
-  selector: 'jhi-payment',
+  selector: 'jhi-categories',
   templateUrl: './categories.component.html',
 })
 export class CategoriesComponent implements OnInit {

--- a/src/main/webapp/app/components/products/display/products.component.html
+++ b/src/main/webapp/app/components/products/display/products.component.html
@@ -1,4 +1,4 @@
-<jhi-payment></jhi-payment>
+<jhi-categories></jhi-categories>
 
 <div>
   <div data-cy="ProductsHeading">

--- a/src/main/webapp/app/components/products/display/products.component.html
+++ b/src/main/webapp/app/components/products/display/products.component.html
@@ -1,3 +1,5 @@
+<jhi-payment></jhi-payment>
+
 <div>
   <div data-cy="ProductsHeading">
     <div *ngIf="this.query === undefined || this.query === ''; else elseBlock">

--- a/src/main/webapp/app/components/products/products.module.ts
+++ b/src/main/webapp/app/components/products/products.module.ts
@@ -4,9 +4,10 @@ import { ProductsRoutingModule } from './route/products-routing.module';
 import { ProductsComponent } from './display/products.component';
 import { ProductCardComponent } from '../reusableComponents/product-card/product-card.component';
 import { ListProductComponent } from '../reusableComponents/list-product/list-product.component';
+import {CategoriesModule} from "../categories/categories.module";
 
 @NgModule({
-  imports: [SharedModule, ProductsRoutingModule],
+  imports: [SharedModule, ProductsRoutingModule, CategoriesModule],
   declarations: [ProductsComponent, ProductCardComponent, ListProductComponent],
 })
 export class ProductsModule {}

--- a/src/main/webapp/app/layouts/main/main.component.html
+++ b/src/main/webapp/app/layouts/main/main.component.html
@@ -4,10 +4,6 @@
   <router-outlet name="navbar"></router-outlet>
 </div>
 
-<div>
-  <router-outlet name="categories"></router-outlet>
-</div>
-
 <div class="container-fluid">
   <div class="card jh-card">
     <router-outlet></router-outlet>

--- a/src/main/webapp/content/css/ecom.css
+++ b/src/main/webapp/content/css/ecom.css
@@ -6,16 +6,7 @@
 .ecom-title-header {
   font-size: 28px;
   margin-bottom: 30px;
-}
-
-.ecom-title-header:after {
-  content: '';
-  background: black;
-  position: absolute;
-  top: 65px;
-  left: 1.5%;
-  height: 1px;
-  width: 150px;
+  border-bottom: 1px solid black;
 }
 
 .ecom-button {


### PR DESCRIPTION
On ne fait plus appel à **CategoriesComponent** dans _../layouts/main/main.component.html_
On le fait dans **ProductsComponent**
Modification de  _selector_ de **CategoriesComponent**: 
      'jhi-payment' devient => 'jhi-categories'
Dans **ecom.css** :
      Suppression de _.ecom-title-header:after_
      Ajout de border-bottom dans _ecom-title-header_


