### PR TITLE
Feature 127: Bug de tags sur les produits en promotion.

### DIFF
--- a/src/main/java/com/m2gi/ecom/domain/Promotion.java
+++ b/src/main/java/com/m2gi/ecom/domain/Promotion.java
@@ -49,9 +49,7 @@ public class Promotion implements Serializable {
         inverseJoinColumns = @JoinColumn(name = "products_id")
     )
     @JsonIgnoreProperties(
-        value = {
-            "category", "relatedCategories", "tags", "recipes", "associatedPromotions", "associatedPromotionalCodes", "favoritesOfs",
-        },
+        value = { "category", "relatedCategories", "recipes", "associatedPromotions", "associatedPromotionalCodes", "favoritesOfs" },
         allowSetters = true
     )
     private Set<Product> products = new HashSet<>();

--- a/src/main/java/com/m2gi/ecom/repository/PromotionRepository.java
+++ b/src/main/java/com/m2gi/ecom/repository/PromotionRepository.java
@@ -28,7 +28,10 @@ public interface PromotionRepository extends JpaRepository<Promotion, Long> {
     @Query("select promotion from Promotion promotion left join fetch promotion.products where promotion.id =:id")
     Optional<Promotion> findOneWithEagerRelationships(@Param("id") Long id);
 
-    @Query("select distinct promotion from Promotion promotion where " + " :instant between promotion.startDate and promotion.endDate")
+    @Query(
+        "select distinct promotion from Promotion promotion left join fetch promotion.products where " +
+        " :instant between promotion.startDate and promotion.endDate"
+    )
     List<Promotion> findActiveWithEagerRelationships(@Param("instant") Instant instant);
 
     @Query(

--- a/src/main/java/com/m2gi/ecom/service/impl/PromotionServiceImpl.java
+++ b/src/main/java/com/m2gi/ecom/service/impl/PromotionServiceImpl.java
@@ -89,7 +89,10 @@ public class PromotionServiceImpl implements PromotionService {
     @Transactional(readOnly = true)
     public List<Promotion> findActiveWithEagerRelationships(Instant instant) {
         log.debug("Request to get Promotions active at : {}", instant);
-        return promotionRepository.findActiveWithEagerRelationships(instant);
+        final List<Promotion> promotions = promotionRepository.findActiveWithEagerRelationships(instant);
+        // To force the loading of the lazily fetched product tags
+        promotions.forEach(promotion -> promotion.getProducts().forEach(product -> product.getTags().isEmpty()));
+        return promotions;
     }
 
     @Override

--- a/src/main/java/com/m2gi/ecom/web/rest/PromotionResource.java
+++ b/src/main/java/com/m2gi/ecom/web/rest/PromotionResource.java
@@ -6,6 +6,7 @@ import com.m2gi.ecom.service.PromotionService;
 import com.m2gi.ecom.web.rest.errors.BadRequestAlertException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -142,6 +143,17 @@ public class PromotionResource {
     public List<Promotion> getAllPromotions(@RequestParam(required = false, defaultValue = "false") boolean eagerload) {
         log.debug("REST request to get all Promotions");
         return promotionService.findAll();
+    }
+
+    /**
+     * {@code GET  /promotions/active} : get all the active promotions.
+     *
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of promotions in body.
+     */
+    @GetMapping("/promotions/active")
+    public List<Promotion> getAllPromotions() {
+        log.debug("REST request to get all Promotions");
+        return promotionService.findActiveWithEagerRelationships(Instant.now());
     }
 
     /**

--- a/src/main/webapp/app/components/services/promotion.service.ts
+++ b/src/main/webapp/app/components/services/promotion.service.ts
@@ -23,6 +23,7 @@ export class PromotionService {
     this.promotionsObs.subscribe();
     this.query().subscribe(res => {
       this.promotions = res.body ?? [];
+      console.log('Promotions', this.promotions);
       this.promotionsSubscriber?.next(this.promotions);
     });
   }
@@ -67,6 +68,6 @@ export class PromotionService {
   }
 
   private query(): Observable<EntityArrayResponseType> {
-    return this.http.get<IPromotion[]>(this.resourceUrl, { observe: 'response' });
+    return this.http.get<IPromotion[]>(`${this.resourceUrl}/active`, { observe: 'response' });
   }
 }


### PR DESCRIPTION
-Promotions: Ne demander que les promotions actuellement actives.
-Ne pas éliminer les tags des produits identifiés depuis les promotions (JsonIgnore).

Signed-off-by: HAMICI Ryadh <hamiciryadh@gmail.com>