### PR TITLE
Feature 128: Duplication des résultats dans la recherche par catégorie.

### DIFF
--- a/src/main/java/com/m2gi/ecom/repository/ProductRepository.java
+++ b/src/main/java/com/m2gi/ecom/repository/ProductRepository.java
@@ -45,6 +45,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("select userDetails from UserDetails userDetails left join fetch userDetails.favorites where userDetails.user.login =:login")
     UserDetails getUserDetails(@Param("login") String login);
 
-    @Query("select product from Product product left join fetch product.relatedCategories rc left join fetch product.tags where :cat = rc")
+    @Query(
+        "select distinct product from Product product left join fetch product.relatedCategories rc left join fetch product.tags where :cat = rc"
+    )
     List<Product> findAllFromCategory(@Param("cat") Category cat, Sort sort);
 }


### PR DESCRIPTION
-Utilisation du mot clé "Distinct" dans la requête de recherche de produits par catégorie afin d'éviter les doublons.

Signed-off-by: HAMICI Ryadh <hamiciryadh@gmail.com>